### PR TITLE
fix number recognization in html tag

### DIFF
--- a/grammars/riot-tag.cson
+++ b/grammars/riot-tag.cson
@@ -6,7 +6,7 @@ patterns: [
   # HTML -------------------------------
   {
     name: 'meta.tag.any.html'
-    begin: '(</?)([a-zA-Z_-]+)'
+    begin: '(</?)([a-zA-Z0-9_-]+)'
     beginCaptures:
       '1':
         name: 'punctuation.definition.tag.begin.html'


### PR DESCRIPTION
This will fix the mis-recognize the `<h1>` to `<h6>` tag, and also the custom tag name with numbers.
