### PR TITLE
Change to work Stylus syntax highlight

### DIFF
--- a/grammars/riot-tag.cson
+++ b/grammars/riot-tag.cson
@@ -92,7 +92,7 @@ patterns: [
         begin: '(>)'
         end: '(?=</style)'
         patterns: [
-          { include: 'source.stylus' }
+          { include: 'source.css.stylus' }
         ]
       }
     ]


### PR DESCRIPTION
Hi,
I tried `<style type="stylus">`, but syntax highlight doesn't work.
I tried to fix `source.stylus` => `source.css.stylus` , in settings at `grammars/riot-tag.cson`. And it works fine.
